### PR TITLE
removed extra p tag, upped version

### DIFF
--- a/src/Yesod/Auth/Facebook/ServerSide.hs
+++ b/src/Yesod/Auth/Facebook/ServerSide.hs
@@ -113,9 +113,7 @@ authFacebook perms = AuthPlugin "fb" dispatch login
     login tm = do
         ur <- getUrlRender
         redirectUrl <- handlerToWidget $ getRedirectUrl (ur . tm)
-        [whamlet|$newline never
-<p>
-    <a href="#{redirectUrl}">_{Msg.Facebook}
+        [whamlet|<a href="#{redirectUrl}">_{Msg.Facebook}
 |]
 
 

--- a/yesod-auth-fb.cabal
+++ b/yesod-auth-fb.cabal
@@ -1,5 +1,5 @@
 Name:                yesod-auth-fb
-Version:             1.8.0
+Version:             1.8.1
 Synopsis:            Authentication backend for Yesod using Facebook.
 Homepage:            https://github.com/psibi/yesod-auth-fb
 License:             BSD3


### PR DESCRIPTION
removing this additional tag means that the login hamlet code is in the same vein as other yesod-auth providers (see e.g. https://github.com/thoughtbot/yesod-auth-oauth2/blob/1dcbb2dbc171021799ef3cb1469df0e1196a4e6d/Yesod/Auth/OAuth2.hs )

it's helpful for me to have them all the same, because they i don't need any special handling and i can just list them all and they're visually consistent.

feel free to ignore this PR if i'ts of no interest, but i'm at least using this version in my own code :)